### PR TITLE
Specify platform to prevent build errors on ARM hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3.9"
 services:
   develop:
+    platform: linux/amd64
     build:
       context: .
-    stdin_open: true 
+    stdin_open: true
     tty: true


### PR DESCRIPTION
On ARM hosts, if unspecified during build, the docker image defaults to an `arm64` image of ubuntu. This causes the install of `wasm-opt` to fail (see [source code](https://github.com/MrRefactoring/wasm-opt/blob/master/bin/index.js) for comparison).

If the platform is specified as `linux/amd64`, the build script runs without errors (tested on M1 Mac).